### PR TITLE
Some small fixes to start scripts

### DIFF
--- a/script/lsb/booth-arbitrator
+++ b/script/lsb/booth-arbitrator
@@ -5,7 +5,7 @@
 # booth-arbitrator	BOOTH arbitrator daemon
 #
 # chkconfig: - 20 20
-# processname:  booth
+# processname:  boothd
 # pidfile:      /var/run/booth.pid
 # description:  Cluster Ticket Registry
 ### BEGIN INIT INFO
@@ -19,7 +19,7 @@
 # Short-Description: start and stop BOOTH arbitrator daemon
 ### END INIT INFO
 
-prog="booth"
+prog="boothd"
 exec="/usr/sbin/$prog"
 type="arbitrator"
 lockfile="/var/run/$prog.pid"

--- a/script/ocf/booth-site
+++ b/script/ocf/booth-site
@@ -104,7 +104,7 @@ booth_start() {
     ${OCF_RESKEY_daemon} $OCF_RESKEY_type $OCF_RESKEY_args
 
     sleep 1
-    controld_monitor
+    booth_monitor
 }
 
 booth_stop() {

--- a/script/ocf/booth-site
+++ b/script/ocf/booth-site
@@ -38,7 +38,7 @@ meta_data() {
 
 <longdesc lang="en">
 This Resource Agent can control the BOOTH site daemon.
-It assumes that the binary booth is in your default PATH.
+It assumes that the binary boothd is in your default PATH.
 In most cases, it should be run as a primitive resource.
 </longdesc>
 <shortdesc lang="en">BOOTH site daemon</shortdesc>
@@ -66,7 +66,7 @@ The type of BOOTH daemon which should be started
 The daemon to start
 </longdesc>
 <shortdesc lang="en">The daemon to start</shortdesc>
-<content type="string" default="booth" />
+<content type="string" default="boothd" />
 </parameter>
 
 </parameters>
@@ -156,8 +156,14 @@ booth_validate() {
     return $OCF_SUCCESS
 }
 
-: ${OCF_RESKEY_type=site}
-: ${OCF_RESKEY_CRM_meta_gloablly_unique:="false"}
+# Set OCF_RESKEY_daemon to boothd as default if not set
+if [ ! ${OCF_RESKEY_daemon} ]; then
+    OCF_RESKEY_daemon=boothd
+fi
+# Set OCF_RESKEY_type to site as default if not set
+if [ ! ${OCF_RESKEY_type} ]; then
+    OCF_RESKEY_type=site
+fi
 
 case $__OCF_ACTION in
 meta-data)	meta_data


### PR DESCRIPTION
Fix not existing function name in booth-site OCF Script
There was a function call named controld_monitor which
was not found in booth-site OCF Script. Perhaps a copy
and paste mistake from the controld Script. Replaced it
with the right function booth_monitor.

Fixes issues like this:

OCF_ROOT=/usr/lib/ocf OCF_RESKEY_daemon=booth \
 /usr/lib/ocf/resource.d/pacemaker/booth-site start
booth: no process found
/usr/lib/ocf/resource.d/pacemaker/booth-site: line 107:
controld_monitor: command not found

Signed-off-by: Joerg Frede frede@b1-systems.de

Fix daemon Name in LSB startscript
While the daemon Name is now boothd not booth i fixed
it in the LSB Startscript.

Signed-off-by: Joerg Frede frede@b1-systems.de

Change daemon name and default values in OCF Script
Changed the daemon name from booth to boothd.
Default value for daemon was not set is now
"boothd" if OCF_RESKEY_daemon is empty.
Default value for type was always set to "site" even
when OCF_RESKEY_type was set to something other.
This now will be checkt and set correctly.
Removed overwriting of OCF_RESOURCE_INSTANCE_gloablly_unique with
false. Because this is already captured in booth_validate function.
If its overwritten no error message will be displayed.

Fixes issues like this:
OCF_ROOT=/usr/lib/ocf OCF_RESKEY_daemon=booth \
/usr/lib/ocf/resource.d/pacemaker/booth-site validate-all
ERROR: Setup problem: couldn't find command:

Signed-off-by: Joerg Frede frede@b1-systems.de
