### PR TITLE
Fixed the PID File name in the lsb startscript

### DIFF
--- a/script/lsb/booth-arbitrator
+++ b/script/lsb/booth-arbitrator
@@ -22,7 +22,7 @@
 prog="boothd"
 exec="/usr/sbin/$prog"
 type="arbitrator"
-lockfile="/var/run/$prog.pid"
+lockfile="/var/run/booth.pid"
 
 [ -f /etc/sysconfig/$prog ] && . /etc/sysconfig/$prog
 

--- a/src/pacemaker.c
+++ b/src/pacemaker.c
@@ -27,7 +27,7 @@ static void pcmk_grant_ticket(const void *ticket)
 	FILE *p;
 	char cmd[COMMAND_MAX];
 
-	snprintf(cmd, COMMAND_MAX, "crm_ticket -t %s -n true", (char *)ticket);
+	snprintf(cmd, COMMAND_MAX, "crm_ticket -t %s -v true", (char *)ticket);
 	log_info("command: '%s' was executed", cmd);
 	p = popen(cmd, "r");
 	if (p == NULL) {
@@ -44,7 +44,7 @@ static void pcmk_revoke_ticket(const void *ticket)
 	FILE *p;
 	char cmd[COMMAND_MAX];
 
-	snprintf(cmd, COMMAND_MAX, "crm_ticket -t %s -n false", (char *)ticket);
+	snprintf(cmd, COMMAND_MAX, "crm_ticket -t %s -v false", (char *)ticket);
 	log_info("command: '%s' was executed", cmd);
 	p = popen(cmd, "r");
 	if (p == NULL) {


### PR DESCRIPTION
The lsb startscript was not been able to stop the boothd
because the PID file name is not boothd.pid it is booth.pid.

Signed-off-by: Joerg Frede frede@b1-systems.de
