### PR TITLE
Add missing import of 're'.

### DIFF
--- a/test/assertions.py
+++ b/test/assertions.py
@@ -1,3 +1,7 @@
+#!/usr/bin/python
+
+import re
+
 class BoothAssertions:
     def configFileMissingMyIP(self, config_file=None, lock_file=None):
         (pid, ret, stdout, stderr, runner) = \


### PR DESCRIPTION
For some reason, this causes test failures on SLES11 SP2 but not on openSUSE 12.1.

That's why I didn't notice it before, sorry :-(
