### PR TITLE
Fix github issue #13 - compile should not fail when help2man is installed

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -22,6 +22,9 @@ EXTRA_DIST		= $(man_MANS)
 
 %.8: %
 	$(HELP2MAN) -N -o $@ ./$<
+
+booth.8: boothd.8
+	cp $< $@
 endif
 
 lint:


### PR DESCRIPTION
Quick fix for issue #13.

See also: https://bugzilla.novell.com/show_bug.cgi?id=753276
