### PR TITLE
Implemented a function to perform of revoke in a single node forcibly.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -971,7 +971,7 @@ static int read_arguments(int argc, char **argv)
 			break;
 
 		case 'f':
-			if (cl.op == OP_GRANT)
+			if (cl.op == OP_GRANT || cl.op == OP_REVOKE)
 				cl.force = 1;
 			else {
 				print_usage();

--- a/src/paxos_lease.c
+++ b/src/paxos_lease.c
@@ -208,6 +208,24 @@ int paxos_lease_release(pl_handle_t handle)
 	return 0;
 }
 
+int paxos_lease_release_force(pl_handle_t handle)
+{
+	struct paxos_lease *pl = (struct paxos_lease *)handle;
+
+	if (pl->acceptor.timer2)
+		del_timer(&pl->acceptor.timer2);
+	if (pl->acceptor.timer1)
+		del_timer(&pl->acceptor.timer1);
+	if (pl->proposer.timer2)
+		del_timer(&pl->proposer.timer2);
+	if (pl->proposer.timer1)
+		del_timer(&pl->proposer.timer1);
+
+	pl->owner = -1;
+
+	return 0;
+}
+
 static int lease_catchup(pi_handle_t handle)
 {
 	struct paxos_lease *pl;

--- a/src/paxos_lease.h
+++ b/src/paxos_lease.h
@@ -64,6 +64,8 @@ int paxos_lease_status_recovery(pl_handle_t handle);
 
 int paxos_lease_release(pl_handle_t handle);
 
+int paxos_lease_release_force(pl_handle_t handle);
+
 int paxos_lease_exit(pl_handle_t handle);
 
 #endif /* _PAXOS_LEASE_H */

--- a/src/ticket.c
+++ b/src/ticket.c
@@ -429,8 +429,10 @@ int revoke_ticket(char *ticket, int force)
 	}
 
 	if (force) {
+		paxos_lease_release_force(tk->handle);
 		pcmk_handler.store_ticket(tk->id, -1, 0, 0);
 		pcmk_handler.revoke_ticket(tk->id);
+		return BOOTHC_RLT_SYNC_SUCC;
 	}
 
 	if (tk->owner == -1)


### PR DESCRIPTION
I implemented a function to perform of revoke in a single node forcibly separately from overall revoke.
I think that this function is employed when admin wants to switch a ticket in another site.
This function is carried out by adding -f option to revoke command.

Example
booth client revoke -t ticketA -s **\* -f
