### PR TITLE
When a expire was not set on a ticket, made modifications to use the def...

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -22,6 +22,7 @@
 #include <string.h>
 #include "booth.h"
 #include "config.h"
+#include "ticket.h"
 #include "log.h"
 
 static int ticket_size = 0;
@@ -220,8 +221,14 @@ int read_config(const char *path)
 			}
 			expiry = index(val, ';');
 			weight = rindex(val, ';');
-			if (!expiry)
+			if (!expiry) {
 				strcpy(booth_conf->ticket[count].name, val);
+				booth_conf->ticket[count].expiry = DEFAULT_TICKET_EXPIRY;
+				log_info("expire is not set in %s."
+					 " Set the default value %ds.",
+					 booth_conf->ticket[count].name,
+					 DEFAULT_TICKET_EXPIRY);
+			}
 			else if (expiry && expiry == weight) {
 				*expiry++ = '\0';
 				while (*expiry == ' ')

--- a/src/ticket.c
+++ b/src/ticket.c
@@ -540,8 +540,6 @@ int setup_ticket(void)
 		strcpy(tk->id, booth_conf->ticket[i].name);
 		tk->owner = -1;
 		tk->expiry = booth_conf->ticket[i].expiry;
-		if (!tk->expiry)
-			tk->expiry = DEFAULT_TICKET_EXPIRY;
 		list_add_tail(&tk->list, &ticket_list); 
 
 		plh = paxos_lease_init(tk->id,


### PR DESCRIPTION
...ault value.

If revoke is performed to the ticket in which the term of validity is not set up, "core dump" will occur.

```
# booth client revoke -t ticketB -s 192.168.102.101
cluster[30930]: 2012/04/09_19:25:33 info: revoke command sent, result will be returned asynchronously, you can get the result from the log files after the ticket expiry time.
cluster[30930]: 2012/04/09_19:25:33 info: You have to wait 0 seconds to ensure all timer has expired!
Floating point exception (core dumped)
```

To fix this, if you do not have expiration date when you read booth.conf, has been modified to use the default value.
