### PR TITLE
Fixed:booth daemons may cause a dead-lock.

### DIFF
--- a/src/booth.h
+++ b/src/booth.h
@@ -65,6 +65,7 @@ typedef enum {
 	BOOTHC_RLT_INVALID_ARG,
 	BOOTHC_RLT_REMOTE_OP,
 	BOOTHC_RLT_OVERGRANT,
+	BOOTHC_RLT_REJECT,
 } cmd_result_t;
 
 struct client {

--- a/src/thread_loop.h
+++ b/src/thread_loop.h
@@ -1,0 +1,42 @@
+/* 
+ * Copyright (C) 2012 NIPPON TELEGRAPH AND TELEPHONE CORPORATION
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+/*
+ * this enum show a thread state.
+ * THREAD_LOOP : A thread is continued.
+ * THREAD_END : A thread is finished.
+ */
+enum thread_s {
+	THREAD_LOOP = 1,
+	THREAD_END,
+} thread_state;
+
+/*
+ * this store process_recv.
+ */
+void (*pthread_process_recv)(int);
+
+/*
+ * this function is implemented about a thread body.
+ */
+void pthread_loop(void);
+
+/*
+ * this function is called in pthread_loop, instead of process_connection.
+ */
+void pthread_process_connection(int ci);

--- a/src/transport.c
+++ b/src/transport.c
@@ -34,6 +34,7 @@
 #include "config.h"
 #include "paxos_lease.h"
 #include "transport.h"
+#include "thread_loop.h"
 
 #define BOOTH_IPADDR_LEN	(sizeof(struct in6_addr))
 
@@ -53,6 +54,7 @@ struct tcp_conn {
 };
 
 static LIST_HEAD(tcp);
+
 
 struct udp_context {
 	int s;
@@ -547,6 +549,7 @@ static int booth_udp_init(void *f)
 
 	deliver_fn = f;
 
+	pthread_process_recv = process_recv;
 	client_add(udp.s, process_recv, NULL);
 
 	return 0;


### PR DESCRIPTION
Problem:
When two or more booth daemons was started at the same time, 
then booth daemons is stopped by pacemaker to cause time-out.
this situation is caused by a dead-lock among booth daemons.
then booth daemons is waiting a received message each other.
And this problem happen the process of　"catch up ticket".

Solution:
I make a thread in the process of　"catch up ticket".
As booth daemons is waiting a received message, we can sent a message to a another node.
