### PR TITLE
Add support for sync revoke of ticket

### DIFF
--- a/src/paxos.h
+++ b/src/paxos.h
@@ -35,6 +35,7 @@ struct paxos_operations {
 	int (*catchup) (pi_handle_t handle);
 	int (*prepare) (pi_handle_t handle, void *extra);
 	int (*promise) (pi_handle_t handle, void *extra);
+	int (*is_prepared) (pi_handle_t handle, void *extra);
 	int (*propose) (pi_handle_t handle, void *extra,
 			int round, void *value);
 	int (*accepted) (pi_handle_t handle, void *extra,

--- a/src/paxos_lease.h
+++ b/src/paxos_lease.h
@@ -21,6 +21,9 @@
 
 #define PLEASE_NAME_LEN		63
 
+#define NOT_CLEAR_RELEASE	0
+#define CLEAR_RELEASE		1
+
 typedef long pl_handle_t;
 
 struct paxos_lease_result {
@@ -51,6 +54,7 @@ pl_handle_t paxos_lease_init(const void *name,
 int paxos_lease_on_receive(void *msg, int msglen);
 
 int paxos_lease_acquire(pl_handle_t handle,
+			int clear,
 			int renew,
 			void (*end_acquire) (pl_handle_t handle, int result));
 /*
@@ -62,7 +66,8 @@ int paxos_lease_timeout(const void *name);
 */
 int paxos_lease_status_recovery(pl_handle_t handle);
 
-int paxos_lease_release(pl_handle_t handle);
+int paxos_lease_release(pl_handle_t handle,
+			void (*end_release) (pl_handle_t handle, int result));
 
 int paxos_lease_exit(pl_handle_t handle);
 


### PR DESCRIPTION
When revoke a ticket, we always need wait a long time (may be
DEFAULT_TICKET_EXPIRY sometimes) now. Revoke time can be greatly
shortened with this patch.
