### PR TITLE
Modify the return value of booth

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -667,7 +667,7 @@ static int do_command(cmd_request_t cmd)
 			log_info("grant failed!");
 		else if (cmd == BOOTHC_CMD_REVOKE)
 			log_info("revoke failed!");
-		rv = 0;
+		rv = -1;
 	} else {
 		log_error("internal error!");
 		rv = -1;


### PR DESCRIPTION
Booth revoke and booth grant will return 0 when grant or revoke tickets failed. This patch fix the issue, it will return error code in the case.

Signed-off-by: Guangliang Zhao gzhao@suse.com
