### PR TITLE
Fixed:tcp listener error and trivial fix

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -611,7 +611,7 @@ static int do_command(cmd_request_t cmd)
 	}
 	
 	if (reply.result == BOOTHC_RLT_OVERGRANT) {
-		log_info("You're granting a granted ticket"
+		log_info("You're granting a granted ticket "
 			 "If you wanted to migrate a ticket,"
 			 "use revoke first, then use grant");
 		rv = -1;

--- a/src/transport.c
+++ b/src/transport.c
@@ -257,7 +257,7 @@ static void process_dead(int ci)
 static void process_tcp_listener(int ci)
 {
 	int fd, i, one = 1;
-	socklen_t addrlen;
+	socklen_t addrlen = sizeof(struct sockaddr);
 	struct sockaddr addr;
 	struct tcp_conn *conn;
 


### PR DESCRIPTION
The booth daemon often cause the following error when we execute "grant" or "revoke".

ERROR: process_tcp_listener: accept error -1 22

Then the command fail. I resolved this issue .
And I add the trivial fix.
