### PR TITLE
Fixed:Change initial round

### DIFF
--- a/src/paxos_lease.c
+++ b/src/paxos_lease.c
@@ -306,10 +306,10 @@ static int lease_catchup(pi_handle_t handle)
 		pl->acceptor.timer1 = add_timer(pl->expires - current_time(),
 						(unsigned long)pl,
 						lease_expires);
-
+	pl->proposer.round = pl->acceptor.round;
 	plr.owner = pl->owner;
 	plr.expires = pl->expires;
-	plr.ballot = pl->proposer.round;
+	plr.ballot = pl->acceptor.round;
 	strcpy(plr.name, pl->name);
 	p_l_op->notify((pl_handle_t)pl, &plr);
 


### PR DESCRIPTION
This fix resolve the problem that I reported bugzilla.

http://bugs.clusterlabs.org/show_bug.cgi?id=5071

If catch up succeed, Then the proposer round level the acceptor round. So the error message was not output when booth updated expire date.
