### PR TITLE
Fixed:change condition when a node send a message to a catchup node

### DIFF
--- a/src/ticket.c
+++ b/src/ticket.c
@@ -536,7 +536,7 @@ int catchup_ticket(char **pdata, unsigned int len)
 			continue;
 
 		tmsg->ballot = tk->ballot;
-		if (tk->owner == ticket_get_myid()
+		if (tk->owner != -1
 				&& current_time() < tk->expires) {
 			tmsg->result = CATCHED_VALID_TMSG;
 			tmsg->expiry = tk->expires - current_time();


### PR DESCRIPTION
This fix relate to Bug 5082.

http://bugs.clusterlabs.org/show_bug.cgi?id=5082

When ACT site restart, ACT site need to get a ticket information from SBY site because there is no a ticket information in cib.
