### PR TITLE
spec:add booth.spec.in file(RedHat 6.2)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -33,7 +33,7 @@ SPEC			= $(PACKAGE_NAME).spec
 
 TARFILE			= $(PACKAGE_NAME)-$(VERSION).tar.gz
 
-EXTRA_DIST		= autogen.sh conf/booth.conf.example 
+EXTRA_DIST		= autogen.sh conf/booth.conf.example $(bootharbitrator_SCRIPTS) $(boothsite_SCRIPTS) 
 
 AUTOMAKE_OPTIONS	= foreign
 
@@ -87,6 +87,10 @@ lint:
 dist-clean-local:
 	rm -f autoconf automake autoheader
 
+dist-hook:
+	echo $(VERSION) > $(distdir)/.tarball-version
+
+
 ## make rpm/srpm section.
 
 $(SPEC): $(SPEC).in
@@ -139,9 +143,11 @@ RPMBUILDOPTS	= --define "_sourcedir $(abs_builddir)" \
 		  --define "_rpmdir $(abs_builddir)"
 
 srpm: clean
+	autoreconf -if
 	$(MAKE) $(SPEC) $(TARFILE)
 	rpmbuild $(RPMBUILDOPTS) --nodeps -bs $(SPEC)
 
 rpm: clean
+	autoreconf -if
 	$(MAKE) $(SPEC) $(TARFILE)
 	rpmbuild $(RPMBUILDOPTS) -ba $(SPEC)

--- a/booth.spec.in
+++ b/booth.spec.in
@@ -1,0 +1,65 @@
+%global alphatag @alphatag@
+%global numcomm @numcomm@
+%global dirty @dirty@
+
+Name:           booth
+Version:        @version@
+Release:        1%{?numcomm:.%{numcomm}}%{?alphatag:.%{alphatag}}%{?dirty:.%{dirty}}%{?dist}
+Summary:        The Booth Cluster Ticket Manager.
+
+Group:          System Environment/Daemons
+License:        GPLv2
+URL:            http://www.clusterlabs.org
+Source0:        %{name}-%{version}.tar.gz
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+Provides:       booth
+
+Requires:       pacemaker
+
+BuildRequires:  autoconf automake libtool cluster-glue-libs-devel help2man
+
+%description
+Booth manages the ticket which authorizes one of the cluster sites located in
+geographically dispersed distances to run certain resources. It is designed to
+be an add-on of Pacemaker, which extends Pacemaker to support geographically
+distributed clustering.
+
+%prep
+%setup -q -n %{name}-%{version}
+
+%build
+./autogen.sh
+
+%configure --with-initddir=%{_initrddir}
+make all
+
+#except check
+#%check
+#make check
+
+%install
+rm -rf %{buildroot}
+make install DESTDIR=%{buildroot}
+
+%clean
+rm -rf %{buildroot}
+
+%files
+%defattr(-,root,root,-)
+%doc %{_docdir}/booth/README 
+%doc %{_docdir}/booth/COPYING
+%{_sbindir}/booth
+%{_sbindir}/boothd
+%config %{_sysconfdir}/booth/booth.conf.example
+%{_mandir}/man8/booth.8.gz
+%{_mandir}/man8/boothd.8.gz
+%dir /usr/lib/ocf/resource.d/pacemaker/
+/usr/lib/ocf/resource.d/pacemaker/booth-site
+%{_initrddir}/booth-arbitrator
+
+
+
+%changelog
+* @date@ Autotools generated version <nobody@nowhere.org> - @version@-1-@numcomm@.@alphatag@.@dirty@
+- Autotools generated version
+


### PR DESCRIPTION
I try to make a spec file. And I tested on RedHat 6.2. However, I don't  have SUSE linux. I cannot guarantee an behavior on SUSE linux. So, I would like to ask that the difference between environments is merged.
