### PR TITLE
Fixed:booth fails in realocating a memory

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -39,7 +39,7 @@ static int ticket_realloc(void)
 		return -ENOMEM;
 	}
 
-	p = booth_conf + sizeof(struct booth_config)
+	p = (char *) booth_conf + sizeof(struct booth_config)
 	    + ticket_size * sizeof(struct ticket_config);
 	memset(p, 0, TICKET_ALLOC * sizeof(struct ticket_config));
 	ticket_size += TICKET_ALLOC;


### PR DESCRIPTION
When we set more than 17 tickets, booth causes "segmentation fault".
And, the pointer specified to memset was out of the reallocate memory range.
I add typecasting because the calculation of pointer is incorrect. 

Signed-off-by: Yuichi SEINO seino.cluster2@gmail.com
