### PR TITLE
Fixed:correct the calculation of quorum in learner

### DIFF
--- a/src/paxos.h
+++ b/src/paxos.h
@@ -25,8 +25,11 @@
 #define ACCEPTOR	0x2
 #define LEARNER		0x1
 
+#define INSTANCE_NUMBER_EMPTY	-1
+
 typedef long ps_handle_t;
 typedef long pi_handle_t;
+
 
 struct paxos_operations {
 	int (*get_myid) (void);
@@ -36,7 +39,8 @@ struct paxos_operations {
 	int (*equal_value) (const void *value1, const void *value2);
 	void (*debug_value) (const void *value);
 	int (*prepare) (pi_handle_t handle, void *extra);
-	int (*promise) (pi_handle_t handle, void *extra, int round);
+	int (*promise) (pi_handle_t handle, void *extra,
+			int proposer_id, int round);
 	int (*is_prepared) (pi_handle_t handle, void *extra);
 	int (*propose) (pi_handle_t handle, void *extra,
 			int round, void *value);
@@ -78,6 +82,13 @@ int paxos_recovery_status_set(pi_handle_t handle, int recovery);
 int paxos_catchup(pi_handle_t handle);
 
 int paxos_propose(pi_handle_t handle, void *value, int round);
+
+int paxos_boost_round(pi_handle_t handle,
+		void *value,
+		int round,
+		void (*end_request) (pi_handle_t handle,
+	     int round,
+	     int result));
 
 int paxos_instance_exit(pi_handle_t handle);
 

--- a/src/paxos.h
+++ b/src/paxos.h
@@ -33,15 +33,18 @@ struct paxos_operations {
 	int (*send) (unsigned long id, void *value, int len);
 	int (*broadcast) (void *value, int len);
 	int (*catchup) (pi_handle_t handle);
+	int (*equal_value) (const void *value1, const void *value2);
+	void (*debug_value) (const void *value);
 	int (*prepare) (pi_handle_t handle, void *extra);
-	int (*promise) (pi_handle_t handle, void *extra);
+	int (*promise) (pi_handle_t handle, void *extra, int round);
 	int (*is_prepared) (pi_handle_t handle, void *extra);
 	int (*propose) (pi_handle_t handle, void *extra,
 			int round, void *value);
 	int (*accepted) (pi_handle_t handle, void *extra,
 			 int round, void *value);
 	int (*commit) (pi_handle_t handle, void *extra, int round);
-	int (*learned) (pi_handle_t handle, void *extra, int round);
+	int (*learned) (pi_handle_t handle, void *extra,
+			int round, void *value);
 };
 
 int paxos_recvmsg(void *msg, int msglen);

--- a/src/paxos_lease.h
+++ b/src/paxos_lease.h
@@ -24,6 +24,7 @@
 #define NOT_CLEAR_RELEASE	0
 #define CLEAR_RELEASE		1
 
+
 typedef long pl_handle_t;
 
 struct paxos_lease_result {
@@ -40,6 +41,7 @@ struct paxos_lease_operations {
 	int (*catchup) (const void *name, int *owner, int *ballot,
 			unsigned long long *expires);
 	int (*notify) (pl_handle_t handle, struct paxos_lease_result *result);
+	void (*end_acquire) (pl_handle_t handle, int error);
 };
 
 pl_handle_t paxos_lease_init(const void *name,

--- a/src/ticket.c
+++ b/src/ticket.c
@@ -553,6 +553,7 @@ const struct paxos_lease_operations ticket_operations = {
 	.broadcast	= ticket_broadcast,
 	.catchup	= ticket_catchup,
 	.notify		= ticket_write,
+	.end_acquire = end_acquire,
 };
 
 int setup_ticket(void)


### PR DESCRIPTION
Learner accumulates the vote when booth runs renew. 
the number of vote exceeds the total of acceptor after a little.
And then, booth always has the quorum.    

I consult the following wiki.
http://en.wikipedia.org/wiki/Paxos_%28computer_science%29

I think that booth implements renew() by using Multi-Paxos. However, booth still doesn't implement the instance number I(ref wiki). So, I add the instance number to paxos message. Learner can discerns a acceptor message in the same round. And, booth can calculate the correct vote number.    
