### PR TITLE
Fixed:booth is the state of "started" on pacemaker before booth write ticket info in cib.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -695,52 +695,63 @@ static int do_revoke(void)
 	return do_command(BOOTHC_CMD_REVOKE);
 }
 
-static int lockfile(void)
+static int open_lockfile(void)
 {
-	char buf[16];
 	struct flock lock;
 	int fd, rv;
 
 	fd = open(cl.lockfile, O_CREAT|O_WRONLY, 0666);
 	if (fd < 0) {
-                log_error("lockfile open error %s: %s",
-                          cl.lockfile, strerror(errno));
-                return -1;
-        }       
+			log_error("lockfile open error %s: %s",
+					  cl.lockfile, strerror(errno));
+			return -1;
+	}
 
-        lock.l_type = F_WRLCK;
-        lock.l_start = 0;
-        lock.l_whence = SEEK_SET;
-        lock.l_len = 0;
-        
-        rv = fcntl(fd, F_SETLK, &lock);
-        if (rv < 0) {
-                log_error("lockfile setlk error %s: %s",
-                          cl.lockfile, strerror(errno));
-                goto fail;
-        }
+	lock.l_type = F_WRLCK;
+	lock.l_start = 0;
+	lock.l_whence = SEEK_SET;
+	lock.l_len = 0;
 
-        rv = ftruncate(fd, 0);
-        if (rv < 0) {
-                log_error("lockfile truncate error %s: %s",
-                          cl.lockfile, strerror(errno));
-                goto fail;
-        }
+	rv = fcntl(fd, F_SETLK, &lock);
+	if (rv < 0) {
+			log_error("lockfile setlk error %s: %s",
+				  cl.lockfile, strerror(errno));
+			goto fail;
+		}
 
-        memset(buf, 0, sizeof(buf));
-        snprintf(buf, sizeof(buf), "%d\n", getpid());
+	rv = ftruncate(fd, 0);
+	if (rv < 0) {
+			log_error("lockfile truncate error %s: %s",
+					  cl.lockfile, strerror(errno));
+			goto fail;
+	}
 
-        rv = write(fd, buf, strlen(buf));
-        if (rv <= 0) {
-                log_error("lockfile write error %s: %s",
-                          cl.lockfile, strerror(errno));
-                goto fail;
-        }
+	return fd;
 
-        return fd;
- fail:
-        close(fd);
-        return -1;
+fail:
+	close(fd);
+	return -1;
+}
+
+static int write_lockfile(int fd)
+{
+	char buf[16];
+	int rv;
+
+	memset(buf, 0, sizeof(buf));
+	snprintf(buf, sizeof(buf), "%d\n", getpid());
+
+	rv = write(fd, buf, strlen(buf));
+	if (rv <= 0) {
+			log_error("lockfile write error %s: %s",
+					  cl.lockfile, strerror(errno));
+			goto fail;
+	}
+
+	return fd;
+fail:
+	close(fd);
+	return -1;
 }
 
 static void unlink_lockfile(int fd)
@@ -980,6 +991,10 @@ static int do_server(int type)
 	int fd = -1;
 	int rv = -1;
 
+	fd = open_lockfile();
+	if (fd < 0)
+		return fd;
+
 	rv = setup(type);
 	if (rv < 0)
 		goto out;
@@ -995,7 +1010,7 @@ static int do_server(int type)
 	  The lock cannot be obtained before the call to daemon(), otherwise
 	  the lockfile would contain the pid of the parent, not the daemon.
 	*/
-	fd = lockfile();
+	fd = write_lockfile(fd);
 	if (fd < 0)
 		return fd;
 

--- a/src/main.c
+++ b/src/main.c
@@ -450,12 +450,14 @@ static int setup_timer(void)
 	return timerlist_init();
 }
 
-static int loop(void)
+static int setup(int type)
 {
-	void (*workfn) (int ci);
-	void (*deadfn) (int ci);
-	int rv, i;
-	
+	int rv;
+
+	rv = setup_config(type);
+	if (rv < 0)
+		goto fail;
+
 	rv = setup_timer();
 	if (rv < 0)
 		goto fail;
@@ -472,6 +474,18 @@ static int loop(void)
 	if (rv < 0)
 		goto fail;
 	client_add(rv, process_listener, NULL);
+
+	return 0;
+
+fail:
+	return -1;
+}
+
+static int loop(void)
+{
+	void (*workfn) (int ci);
+	void (*deadfn) (int ci);
+	int rv, i;
 
         while (1) {
                 rv = poll(pollfd, client_maxi + 1, poll_timeout);
@@ -966,7 +980,7 @@ static int do_server(int type)
 	int fd = -1;
 	int rv = -1;
 
-	rv = setup_config(type);
+	rv = setup(type);
 	if (rv < 0)
 		goto out;
 


### PR DESCRIPTION
I tried fixing this issue by using revert the commit. 
I don't move daemon(),　instead I move the function to open a lockfile().
