### PR TITLE
Correction of a resource monitor function.

### DIFF
--- a/booth.spec.in
+++ b/booth.spec.in
@@ -1,4 +1,4 @@
-%bcond_with resource-monitor
+%bcond_with resource_monitor
 
 %global alphatag @alphatag@
 %global numcomm @numcomm@
@@ -36,7 +36,7 @@ distributed clustering.
 ./autogen.sh
 
 %configure \
-%if %{with resource-monitor}
+%if %{with resource_monitor}
 	--enable-resource-monitor \
 %endif
 	--with-initddir=%{_initrddir}
@@ -66,6 +66,9 @@ rm -rf %{buildroot}
 %dir /usr/lib/ocf/resource.d/pacemaker/
 /usr/lib/ocf/resource.d/pacemaker/booth-site
 %{_initrddir}/booth-arbitrator
+%if %{with resource_monitor}
+%{_sbindir}/booth_resource_monitord
+%endif
 
 
 

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -22,6 +22,8 @@ INCLUDES                = -I/usr/include/pacemaker \
                         -I$(srcdir)
 
 if RESOURCE_MONITOR
+noinst_HEADERS         = booth_resource_monitord.h
+
 sbin_PROGRAMS          = booth_resource_monitord
 
 # BUILD

--- a/tools/booth_resource_monitord.c
+++ b/tools/booth_resource_monitord.c
@@ -61,7 +61,6 @@
 #include "booth_resource_monitord.h"
 
 GMainLoop *mainloop;
-const char *crm_system_name = "booth_resource_monitord";
 char *booth_config_file;
 char *pid_file;
 int max_failures = 30;
@@ -1938,9 +1937,8 @@ int main(int argc, char **argv)
 
 	booth_config_file = strdup(BOOTH_CONFIG_FILE);
 	pid_file = strdup(PID_FILE);
-	crm_system_name = basename(argv[0]);
 
-	crm_log_init(crm_system_name, LOG_INFO, TRUE, FALSE, argc, argv, FALSE);
+	crm_log_init(basename(argv[0]), LOG_INFO, TRUE, FALSE, argc, argv, FALSE);
 
 	while (1) {
 #ifdef HAVE_GETOPT_H


### PR DESCRIPTION
I coped with the following problems.

The occurring problem was solved when it combined with the newest Pacemaker.
Correction of the problem by which booth_resource_monitord is not contained in RPM.
